### PR TITLE
Update TK4 links according to renamed repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,11 @@
       </div>
 
       <div class="project">
-        <h3><a href="http://github.com/suomipelit/tapankaikki/">Tapan Kaikki 4: Bloodshed</a></h3>
+        <h3><a href="http://github.com/suomipelit/tapankaikki4/">Tapan Kaikki 4: Bloodshed</a></h3>
         <p>Successor of Ultimate Tapan Kaikki.</p>
         <ul class="downloads">
           <li>
-            <a href="https://github.com/suomipelit/tapankaikki/releases/download/v4.09/Tapan.Kaikki.4.09.zip">
+            <a href="https://github.com/suomipelit/tapankaikki4/releases/download/v4.09/Tapan.Kaikki.4.09.zip">
               <img src="windows.svg" /> <span class="ver">v4.09</span> Windows x86 .zip
             </a>
           </li>


### PR DESCRIPTION
TK4 repository was renamed from `tapankaikki` to `tapankaikki4` to avoid confusion. Old links currently link correctly but not sure how long.